### PR TITLE
Database-Initializer: add mock data on startup

### DIFF
--- a/Data/MockDataInitializer.cs
+++ b/Data/MockDataInitializer.cs
@@ -1,0 +1,29 @@
+﻿using Acuedify.Models;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System.Text.Json;
+
+namespace Acuedify.Data
+{
+    public class MockDataInitializer
+    {
+
+        public static void SeedQuizzes(AppDBContext context, string filePath)
+        {
+            try
+            {
+                string quizJson = File.ReadAllText(filePath);
+                var quizzes = JsonSerializer.Deserialize<List<Quiz>>(quizJson);
+                if (quizzes != null)
+                {
+                    context.AddRange(quizzes);
+                    context.SaveChanges();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+        }
+
+    }
+}

--- a/Data/MockDataInitializer.cs
+++ b/Data/MockDataInitializer.cs
@@ -6,13 +6,12 @@ namespace Acuedify.Data
 {
     public class MockDataInitializer
     {
-
         public static void SeedQuizzes(AppDBContext context, string filePath)
         {
             try
             {
-                string quizJson = File.ReadAllText(filePath);
-                var quizzes = JsonSerializer.Deserialize<List<Quiz>>(quizJson);
+                string listOfQuizzesJson = File.ReadAllText(filePath);
+                var quizzes = JsonSerializer.Deserialize<List<Quiz>>(listOfQuizzesJson);
                 if (quizzes != null)
                 {
                     context.AddRange(quizzes);

--- a/MockData/quizzes.json
+++ b/MockData/quizzes.json
@@ -1,0 +1,109 @@
+[
+  {
+    "Title": "Simple Quiz",
+    "Description": "Simple Quiz Description",
+    "isFavorite": false,
+    "Questions": [
+      {
+        "Term": "Simple Question 1",
+        "Definition": "Simple Answer 1"
+      },
+      {
+        "Term": "Simple Question 2",
+        "Definition": "Simple Answer 2"
+      },
+      {
+        "Term": "Simple Question 3",
+        "Definition": "Simple Answer 3"
+      },
+      {
+        "Term": "Simple Question 4",
+        "Definition": "Simple Answer 4"
+      },
+      {
+        "Term": "Simple Question 5",
+        "Definition": "Simple Answer 5"
+      }
+    ]
+  },
+  {
+    "Title": "Favorite Quiz",
+    "Description": "Favorite Quiz Description",
+    "isFavorite": true,
+    "Questions": [
+      {
+        "Term": "Favorite Question 1",
+        "Definition": "Favorite Answer 1"
+      },
+      {
+        "Term": "Favorite Question 2",
+        "Definition": "Favorite Answer 2"
+      },
+      {
+        "Term": "Favorite Question 3",
+        "Definition": "Favorite Answer 3"
+      },
+      {
+        "Term": "Favorite Question 4",
+        "Definition": "Favorite Answer 4"
+      }
+    ]
+  },
+  {
+    "Title": "Long Quiz",
+    "Description": "Long Quiz Description",
+    "isFavorite": false,
+    "Questions": [
+      {
+        "Term": "Long Question 1",
+        "Definition": "Long Answer 1"
+      },
+      {
+        "Term": "Long Question 2",
+        "Definition": "Long Answer 2"
+      },
+      {
+        "Term": "Long Question 3",
+        "Definition": "Long Answer 3"
+      },
+      {
+        "Term": "Long Question 4",
+        "Definition": "Long Answer 4"
+      },
+      {
+        "Term": "Long Question 5",
+        "Definition": "Long Answer 5"
+      },
+      {
+        "Term": "Long Question 6",
+        "Definition": "Long Answer 6"
+      },
+      {
+        "Term": "Long Question 7",
+        "Definition": "Long Answer 7"
+      },
+      {
+        "Term": "Long Question 8",
+        "Definition": "Long Answer 8"
+      },
+      {
+        "Term": "Long Question 9",
+        "Definition": "Long Answer 9"
+      },
+      {
+        "Term": "Long Question 10",
+        "Definition": "Long Answer 10"
+      },
+      {
+        "Term": "Long Question 11",
+        "Definition": "Long Answer 11"
+      }
+    ]
+  },
+  {
+    "Title": "Empty Quiz",
+    "Description": "Quiz Description",
+    "isFavorite": false,
+    "Questions": []
+  }
+]

--- a/MockData/quizzes.json
+++ b/MockData/quizzes.json
@@ -102,7 +102,7 @@
   },
   {
     "Title": "Empty Quiz",
-    "Description": "Quiz Description",
+    "Description": "Empty Quiz Description",
     "isFavorite": false,
     "Questions": []
   }

--- a/Program.cs
+++ b/Program.cs
@@ -14,8 +14,8 @@ builder.Services.AddControllersWithViews();
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 builder.Services.AddDbContext<AppDBContext>(options => options.UseSqlServer(
-	builder.Configuration.GetConnectionString("DefaultConnection")
-	));
+    builder.Configuration.GetConnectionString("DefaultConnection")
+));
 
 builder.Services.AddScoped<ILibraryService, LibraryService>();
 builder.Services.AddScoped<IPlayingService, PlayingService>();
@@ -23,15 +23,15 @@ builder.Services.AddScoped<IPlayingService, PlayingService>();
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession(options =>
 {
-	options.IdleTimeout = TimeSpan.FromMinutes(30); // Set the session timeout as needed
-	options.Cookie.HttpOnly = true;
-	options.Cookie.IsEssential = true;
+    options.IdleTimeout = TimeSpan.FromMinutes(30); // Set the session timeout as needed
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
 });
 
 builder.Services.Configure<CookiePolicyOptions>(options =>
 {
-	options.CheckConsentNeeded = context => true;
-	options.MinimumSameSitePolicy = SameSiteMode.None;
+    options.CheckConsentNeeded = context => true;
+    options.MinimumSameSitePolicy = SameSiteMode.None;
 });
 
 //builder.Services.AddRazorPages().AddRazorRuntimeCompilation();
@@ -41,9 +41,9 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
-	app.UseExceptionHandler("/Home/Error");
-	app.UseStatusCodePagesWithReExecute("/Home/Error/{0}");
-	app.UseHsts();
+    app.UseExceptionHandler("/Home/Error");
+    app.UseStatusCodePagesWithReExecute("/Home/Error/{0}");
+    app.UseHsts();
 }
 
 app.UseHttpsRedirection();
@@ -56,7 +56,16 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapControllerRoute(
-	name: "default",
-	pattern: "{controller=Home}/{action=Index}/{id?}");
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}");
+
+using (var scope = app.Services.CreateScope())
+{
+    var appDBContext = scope.ServiceProvider.GetRequiredService<AppDBContext>();
+    if (!appDBContext.Quizzes.Any())
+    {
+        MockDataInitializer.SeedQuizzes(appDBContext, "MockData/quizzes.json");
+    }
+}
 
 app.Run();

--- a/Tests/LibraryControllerTests.cs
+++ b/Tests/LibraryControllerTests.cs
@@ -1,6 +1,0 @@
-﻿namespace Acuedify.Tests
-{
-	public class LibraryControllerTests
-	{
-	}
-}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=acuedify-db;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }


### PR DESCRIPTION
On startup, if database does not have any Quizzes it will add the quizzes from `MockData/quizzes.json` file.  

Also changed our db name to `acuedify-db`. You will have to run `Update-Database` inside Package Manager Console to make this work. Additionally you may want to remove old database, for this run `Drop-Database` inside Package Manager Console.